### PR TITLE
Take the node name from the pod name in the deployment

### DIFF
--- a/k8s-deployment.yaml
+++ b/k8s-deployment.yaml
@@ -59,7 +59,7 @@ spec:
           env:
             - name: DEFAULT_NODE_NAME
               valueFrom:
-                fieldFrom:
+                fieldRef:
                   fieldPath: metadata.name
             - name: NODE_CPU
               value: "200"

--- a/k8s-deployment.yaml
+++ b/k8s-deployment.yaml
@@ -58,7 +58,9 @@ spec:
             - containerPort: 80
           env:
             - name: DEFAULT_NODE_NAME
-              value: "mocklet"
+              valueFrom:
+                fieldFrom:
+                  fieldPath: metadata.name
             - name: NODE_CPU
               value: "200"
             - name: NODE_MEMORY


### PR DESCRIPTION
When running the deployment with multiple replicas only one node with the name "mocklet" is created. My patch takes the node-name from the pod-name which is unique.